### PR TITLE
meta-click on node and open in new tab

### DIFF
--- a/ui/pages/map/script.js
+++ b/ui/pages/map/script.js
@@ -95,6 +95,8 @@
     var node = svg.selectAll(".node")
           .data(data.nodes)
           .enter()
+            .append("svg:a")
+            .attr('xlink:href', function(d) { return d.url })
             .append("circle")
               .attr("class", "node")
               .attr("r", 5)
@@ -133,7 +135,7 @@
       o[kv[0]] = kv[1];
     });
     assignmentId = parseInt(o.assignment);
-  }
+  };
 
   chrome.runtime.sendMessage({ action: "getLog", assignmentId: assignmentId }, function(response) {
     render("#map", d3ify( response.data ));


### PR DESCRIPTION
this was easier than I thought. Thought i'd have to go through  background.js and statemanager to register custom keypress states then attach a click listener to nodes. Turns out svg has a svg:a element so 2 lines of js. 
