### PR TITLE
[needs review] remove chunky info from tooltip

### DIFF
--- a/ui/pages/js/build/map.js
+++ b/ui/pages/js/build/map.js
@@ -80,7 +80,7 @@
       .offset([0, 10])
       .attr("class", "d3-tip")
       .html(function(d) {
-        return "<pre>" + syntaxHighlight(JSON.stringify(d, null, 3)) + "</pre>";
+        return "<pre>" + syntaxHighlight(JSON.stringify({title: d.title, url: d.url}, null, 3)) + "</pre>";
       });
 
     var width = 960,


### PR DESCRIPTION
I'm assuming the nodes have favicons so the user gets a sense of where they are. 
