### PR TITLE
Replacing google searches tooltips titles with the query terms

### DIFF
--- a/src/components/node-popover.js
+++ b/src/components/node-popover.js
@@ -113,7 +113,7 @@ export default class NodePopover extends React.Component {
       content = <div className={classNames}>
         <div className='content'>
 
-          <h1>{title}</h1>
+          <h1>{this.isGoogleUrl(title, this.props.node.url)}</h1>
 
           <div className='detail'>
             <a className='url' target='_blank' href={this.props.node.url}>{this.props.node.url}</a>
@@ -130,6 +130,23 @@ export default class NodePopover extends React.Component {
       onMouseLeave={this.onMouseLeave.bind(this)}>
       {content}
     </div>
+  }
+
+  isGoogleUrl(title, url){
+      var res = url;
+      if( url.indexOf("https://www.google") == 0 ){
+          var qpos = url.indexOf("#q")
+          if( qpos > -1 ) {
+              res = url.slice(qpos, url.length);
+              res = res.replace('#q=', '')
+              res = res.replace(/\+/g, ' ')
+              return res;
+          }else{
+              return title;
+          }
+      }else{
+          return title;
+      }
   }
 
 };


### PR DESCRIPTION
The branch adds the code so that the Google nodes don't display the google search title:

![image](https://cloud.githubusercontent.com/assets/1418789/16436479/89359b70-3d74-11e6-880c-7d5612e49b83.png)

Instead, the tooltip display's the search terms as the title.
![image](https://cloud.githubusercontent.com/assets/1418789/16436465/762ab7c2-3d74-11e6-8da1-50b057249927.png)
- The **isGoogleUrl** function was created to achieve this.
